### PR TITLE
1108: dynamically set login auth endpoint

### DIFF
--- a/lib/looker-sdk/authentication.rb
+++ b/lib/looker-sdk/authentication.rb
@@ -51,7 +51,7 @@ module LookerSDK
 
       set_access_token_from_params(nil)
       without_authentication do
-        post('/login', {}, :query => application_credentials)
+        post("#{URI.parse(api_endpoint).path}/login", {}, :query => application_credentials)
         raise "login failure #{last_response.status}" unless last_response.status == 200
         set_access_token_from_params(last_response.data)
       end


### PR DESCRIPTION
newer versions of looker require you to hit
a more specific login api endpoint:
/api/3.0/login or
/api/4.0/login

https://bdtrust.atlassian.net/browse/PROD-1108

# Notes to Reviewers
The new version of looker-sdk updates the code that calls the login endpoint like so:
- https://github.com/looker-open-source/looker-sdk-ruby/blob/683c7dbd25dad9040f5b83766d77a1571b7464ce/lib/looker-sdk/authentication.rb#L55

I've partially ported that updated to our fork of the gem, so that prism can continue to use it successfully, and we can punt on dealing with the faraday dependency headache for a little while longer.

Kayak is currently not using our forked version of looker-sdk, so I'm hoping I can just update it to the newer version of looker-sdk without running into any dependencies problems 